### PR TITLE
Fix room change logic

### DIFF
--- a/lightyear_demo/Cargo.lock
+++ b/lightyear_demo/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "parking_lot",
+ "parking_lot 0.12.1",
  "thiserror",
  "windows-sys 0.48.0",
  "x11rb",
@@ -583,7 +583,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.12.1",
  "ron",
  "serde",
  "thiserror",
@@ -1323,8 +1323,7 @@ dependencies = [
 [[package]]
 name = "bitcode_lightyear_patch"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82d186a0148ef9a83a4c8129acf71485a273a5650fcb47cbf66d361615dc660"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=cb/interest-management-bug#9580330f7f5754c3c33f2b50726e958a089aee2f"
 dependencies = [
  "bitcode_derive",
  "bytemuck",
@@ -1549,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1951,7 +1950,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2165,7 +2164,7 @@ dependencies = [
  "ecolor",
  "emath",
  "nohash-hasher",
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -2522,7 +2521,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -2638,7 +2637,7 @@ dependencies = [
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
- "parking_lot",
+ "parking_lot 0.12.1",
  "portable-atomic",
  "quanta 0.12.2",
  "rand",
@@ -3214,8 +3213,7 @@ dependencies = [
 [[package]]
 name = "lightyear"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410945fe163a11eee759ffbe8beff893d259e276ce1823ff63ec5b18b8e249ba"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=cb/interest-management-bug#9580330f7f5754c3c33f2b50726e958a089aee2f"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3245,6 +3243,7 @@ dependencies = [
  "metrics-util 0.15.1",
  "mock_instant",
  "nonzero_ext",
+ "object-pool",
  "paste",
  "rand",
  "ring 0.17.8",
@@ -3290,8 +3289,7 @@ dependencies = [
 [[package]]
 name = "lightyear_macros"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc977b2d3f117608514cc692340599953f7666235c878f02f44e58f51bd9ad0"
+source = "git+https://github.com/cBournhonesque/lightyear.git?branch=cb/interest-management-bug#9580330f7f5754c3c33f2b50726e958a089aee2f"
 dependencies = [
  "anyhow",
  "darling",
@@ -3854,6 +3852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object-pool"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9a3e7196d09ec86002b939f1576e8e446d58def8fd48fe578e2c72d5328d68"
+dependencies = [
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,12 +4022,37 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4386,6 +4418,15 @@ name = "rectangle-pack"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5538,7 +5579,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle 0.6.0",
  "smallvec",
@@ -5566,7 +5607,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle 0.6.0",
  "rustc-hash",
@@ -5608,7 +5649,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "range-alloc",
  "raw-window-handle 0.6.0",
@@ -6023,9 +6064,9 @@ dependencies = [
 
 [[package]]
 name = "wtransport-proto"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d19ee96cc428b718c1557e327c47016e12147adf773e050ae86384198699f57"
+checksum = "394b6588219ddc2ad6bd4ffd2a94d5ad6858ecf02acdd7d39680ba8933103eb9"
 dependencies = [
  "httlib-huffman",
  "octets",

--- a/lightyear_demo/Cargo.toml
+++ b/lightyear_demo/Cargo.toml
@@ -9,7 +9,7 @@ mock_time = ["lightyear/mock_time"]
 
 [dependencies]
 leafwing-input-manager = "0.13"
-lightyear = { version = "0.12.0", features = [
+lightyear = { git = "https://github.com/cBournhonesque/lightyear.git", branch = "cb/interest-management-bug", features = [
   "webtransport",
   "websocket",
   "render",


### PR DESCRIPTION
The room change logic works when using my fixed branch, thanks!

Also I noticed that you did something strange with the grid entities; you give them a `PlayerId` and a `LastPosition` so they also get queries in the `interest_management` system. Instead I just put each grid square in the corresponding room. 
So when the client enters room A, it will start seeing the grid corresponding to room A.